### PR TITLE
Fix typo in `pipeline-guides.lit`

### DIFF
--- a/lit/docs/guides/pipeline-guides.lit
+++ b/lit/docs/guides/pipeline-guides.lit
@@ -405,7 +405,7 @@
     \codeblock{bash}{{
     fly -t tutorial set-pipeline -p parallel-artifacts -c parallel-artifacts.yml
     fly -t tutorial unpause-pipeline -p parallel-artifacts
-    fly -t tutorial trigger-job --job parallel-artifacts/writing-in-parallel --watch
+    fly -t tutorial trigger-job --job parallel-artifacts/writing-to-the-same-output-in-parallel --watch
     fly -t tutorial trigger-job --job parallel-artifacts/writing-to-the-same-output-serially --watch
     }}
   }


### PR DESCRIPTION
This is just a minor correction to an example Bash command in the pipelines guide.